### PR TITLE
Custom Action Handler: fix logic to properly handle errors, timeouts and cancellations

### DIFF
--- a/data/example/custom_action/custom_action.json
+++ b/data/example/custom_action/custom_action.json
@@ -19,8 +19,8 @@
                         {
                                 "cmd": {
                                         "type": "LONG",
-                                        "target_system": 0,
-                                        "target_component": 0,
+                                        "target_system": 1,
+                                        "target_component": 1,
                                         "frame": 0,
                                         "command": 21,
                                         "param1": null,
@@ -61,8 +61,8 @@
                         {
                                 "cmd": {
                                         "type": "LONG",
-                                        "target_system": 0,
-                                        "target_component": 0,
+                                        "target_system": 1,
+                                        "target_component": 1,
                                         "frame": 0,
                                         "command": 22,
                                         "param1": null,
@@ -110,11 +110,32 @@
         },
         "action_3": {
                 "name": "Package delivery with winch action",
-                "description": "Example action of a delivery with a winch procedure",
+                "description": "Example action of a delivery with a winch control",
                 "global_script": "",
                 "global_timeout": null,
                 "action_complete_condition": "ON_LAST_STAGE_COMPLETE",
                 "stages": [{
+                                "cmd": {
+                                        "type": "LONG",
+                                        "target_system": 1,
+                                        "target_component": 1,
+                                        "frame": 0,
+                                        "command": 176,
+                                        "param1": 1,
+                                        "param2": 4,
+                                        "param3": 3,
+                                        "param4": null,
+                                        "param5": null,
+                                        "param6": null,
+                                        "param7": null,
+                                        "is_local": false
+                                },
+                                "script": "",
+                                "parameter_set": {},
+                                "state_transition_condition": "ON_RESULT_SUCCESS",
+                                "timeout": null
+                        },
+                        {
                                 "cmd": {},
                                 "script": "python3 /shared_container_dir/autopilot-manager/data/custom_action/custom_action_scripts/dummy_winch.py -p 14591 --descend",
                                 "parameter_set": {},

--- a/data/example/custom_action/custom_action_scripts/dummy_safe_landing.py
+++ b/data/example/custom_action/custom_action_scripts/dummy_safe_landing.py
@@ -49,7 +49,6 @@ import sys
 from time import sleep
 from mavsdk import System
 from mavsdk.server_utility import StatusTextType
-from mavsdk.telemetry import LandedState
 
 
 async def run() -> None:
@@ -77,8 +76,6 @@ async def run() -> None:
             print(f"[Custom Action Script ] System discovered!")
             break
 
-    # asyncio.ensure_future(get_landed_state(system))
-
     print("\n[Custom Action Script ]  - Safe landing started!\n")
     # Send STATUSTEXT MAVLink message
     await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Safe landing started!')
@@ -88,20 +85,6 @@ async def run() -> None:
     print("[Custom Action Script ]  - Executing area verification while descending...\n")
     # Send STATUSTEXT MAVLink message
     await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Executing area verification while descending...')
-
-    # Wait until landed
-    await get_landed_state(system)
-
-    print("[Custom Action Script ]  - Safe land executed.\n")
-    # Send STATUSTEXT MAVLink message
-    await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Safe land executed!')
-
-
-async def get_landed_state(system: System):
-    """ Subscribe to Landed State """
-    async for landing_state in system.telemetry.landed_state():
-        if (landing_state == LandedState.ON_GROUND):
-            return landing_state
 
 
 if __name__ == '__main__':

--- a/data/example/custom_action/custom_action_sitl.json
+++ b/data/example/custom_action/custom_action_sitl.json
@@ -19,8 +19,8 @@
                         {
                                 "cmd": {
                                         "type": "LONG",
-                                        "target_system": 0,
-                                        "target_component": 0,
+                                        "target_system": 1,
+                                        "target_component": 1,
                                         "frame": 0,
                                         "command": 21,
                                         "param1": null,
@@ -61,8 +61,8 @@
                         {
                                 "cmd": {
                                         "type": "LONG",
-                                        "target_system": 0,
-                                        "target_component": 0,
+                                        "target_system": 1,
+                                        "target_component": 1,
                                         "frame": 0,
                                         "command": 22,
                                         "param1": null,
@@ -110,11 +110,32 @@
         },
         "action_3": {
                 "name": "Package delivery with winch action",
-                "description": "Example action of a delivery with a winch procedure",
+                "description": "Example action of a delivery with a winch control",
                 "global_script": "",
                 "global_timeout": null,
                 "action_complete_condition": "ON_LAST_STAGE_COMPLETE",
                 "stages": [{
+                                "cmd": {
+                                        "type": "LONG",
+                                        "target_system": 1,
+                                        "target_component": 1,
+                                        "frame": 0,
+                                        "command": 176,
+                                        "param1": 1,
+                                        "param2": 4,
+                                        "param3": 3,
+                                        "param4": null,
+                                        "param5": null,
+                                        "param6": null,
+                                        "param7": null,
+                                        "is_local": false
+                                },
+                                "script": "",
+                                "parameter_set": {},
+                                "state_transition_condition": "ON_RESULT_SUCCESS",
+                                "timeout": null
+                        },
+                        {
                                 "cmd": {},
                                 "script": "python3 install/autopilot-manager/share/autopilot-manager/data/example/custom_action/custom_action_scripts/dummy_winch.py -p 14591 --descend",
                                 "parameter_set": {},


### PR DESCRIPTION
The logic on the handler had issues. This is now far more tested and robustified, including sequences of actions where one action fails and the other succeed, or various actions timeout and one succeeds, etc.

Missing at this point, for a better control of the scripting, a way to kill the scripts execution when a cancel command arrives (at this point we can't add blocking functions on the scripts).