### PR TITLE
Custom Action Handler: Improve error and timeout handling

### DIFF
--- a/data/example/custom_action/custom_action_scripts/dummy_air_quality_sensor.py
+++ b/data/example/custom_action/custom_action_scripts/dummy_air_quality_sensor.py
@@ -49,6 +49,22 @@ import sys
 from mavsdk import System
 from mavsdk.server_utility import StatusTextType
 
+# Global return exit value
+ret = 0
+
+
+async def get_connection(system, ip_address, udp_port):
+    """Get connection."""
+    # Create a MAVLink connection to a system through a specific IP address
+    # and UDP port
+    await system.connect(system_address="udp://" + ip_address + ":" + udp_port)
+
+    print("[Custom Action Script ] Waiting for system to connect...")
+    async for state in system.core.connection_state():
+        if state.is_connected:
+            print(f"[Custom Action Script ] System discovered!")
+            break
+
 
 async def run() -> None:
     """Main funtion."""
@@ -60,6 +76,9 @@ async def run() -> None:
                         required=False)
     parser.add_argument('-p', '--port', dest='port', action="store",
                         help="mavlink-router UDP port", required=True)
+    parser.add_argument('-t', '--timeout', dest='timeout', action="store",
+                        help="Amount of time, in seconds, to wait for system connection",
+                        default=3.0, required=False, type=float)
     parser.add_argument('--on', dest='activation', action="store_true",
                         help="Turn air quality sensor on")
     parser.add_argument('--off', dest='activation', action="store_false",
@@ -70,27 +89,32 @@ async def run() -> None:
 
     # Init own system (1:MAV_COMP_ID_USER10)
     system = System(sysid=1, compid=34)
-    # Create a MAVLink connection to a system through a specific IP address
-    # and UDP port
-    await system.connect(system_address="udp://" + args.address + ":" + args.port)
 
-    print("[Custom Action Script ] Waiting for system to connect...")
-    async for state in system.core.connection_state():
-        if state.is_connected:
-            print(f"[Custom Action Script ] System discovered!")
-            break
+    # Wait for a system to be connected for 3 seconds
+    # If timeout, exit with error
+    try:
+        await asyncio.wait_for(get_connection(system, args.address, args.port), timeout=args.timeout)
 
-    if args.activation:
-        print("\n[Custom Action Script ]  - Air quality sensor turned on!\n")
-        # Send STATUSTEXT MAVLink message
-        await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Air quality sensor turned on!')
-    else:
-        print("\n[Custom Action Script ]  - Air quality sensor turned off!\n")
-        # Send STATUSTEXT MAVLink message
-        await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Air quality sensor turned off!')
+        if args.activation:
+            print("\n[Custom Action Script ]  - Air quality sensor turned on!\n")
+            # Send STATUSTEXT MAVLink message
+            await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Air quality sensor turned on!')
+        else:
+            print("\n[Custom Action Script ]  - Air quality sensor turned off!\n")
+            # Send STATUSTEXT MAVLink message
+            await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Air quality sensor turned off!')
+
+    except asyncio.TimeoutError:
+        global ret
+        ret = 1
+        print(
+            '[Custom Action Script ] Failed to connect to system after {} seconds. Action failed!'.format(args.timeout))
 
 
 if __name__ == '__main__':
     # Start the event loop
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(run())
+    try:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(run())
+    finally:
+        sys.exit(ret)

--- a/data/example/custom_action/custom_action_scripts/dummy_cargo_compartment.py
+++ b/data/example/custom_action/custom_action_scripts/dummy_cargo_compartment.py
@@ -50,6 +50,22 @@ from time import sleep
 from mavsdk import System
 from mavsdk.server_utility import StatusTextType
 
+# Global return exit value
+ret = 0
+
+
+async def get_connection(system, ip_address, udp_port):
+    """Get connection."""
+    # Create a MAVLink connection to a system through a specific IP address
+    # and UDP port
+    await system.connect(system_address="udp://" + ip_address + ":" + udp_port)
+
+    print("[Custom Action Script ] Waiting for system to connect...")
+    async for state in system.core.connection_state():
+        if state.is_connected:
+            print(f"[Custom Action Script ] System discovered!")
+            break
+
 
 async def run() -> None:
     """Main funtion."""
@@ -61,6 +77,9 @@ async def run() -> None:
                         required=False)
     parser.add_argument('-p', '--port', dest='port', action="store",
                         help="mavlink-router UDP port", required=True)
+    parser.add_argument('-t', '--timeout', dest='timeout', action="store",
+                        help="Amount of time, in seconds, to wait for system connection",
+                        default=3.0, required=False, type=float)
     parser.add_argument('--open', dest='activation', action="store_true",
                         help="Open cargo compartment latch")
     parser.add_argument('--close', dest='activation', action="store_false",
@@ -71,28 +90,33 @@ async def run() -> None:
 
     # Init own system (1:MAV_COMP_ID_USER11)
     system = System(sysid=1, compid=35)
-    # Create a MAVLink connection to a system through a specific IP address
-    # and UDP port
-    await system.connect(system_address="udp://" + args.address + ":" + args.port)
 
-    print("[Custom Action Script ] Waiting for system to connect...")
-    async for state in system.core.connection_state():
-        if state.is_connected:
-            print(f"System discovered!")
-            break
+    # Wait for a system to be connected for 3 seconds
+    # If timeout, exit with error
+    try:
+        await asyncio.wait_for(get_connection(system, args.address, args.port), timeout=args.timeout)
 
-    if args.activation:
-        print("\n[Custom Action Script ]  - Opening cargo compartment latch...\n")
-        # Send STATUSTEXT MAVLink message
-        await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Opening cargo compartment latch...')
-        sleep(3)
-    else:
-        print("\n[Custom Action Script ]  - Closing cargo compartment latch...\n")
-        await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Closing cargo compartment latch...')
-        sleep(3)
+        if args.activation:
+            print("\n[Custom Action Script ]  - Opening cargo compartment latch...\n")
+            # Send STATUSTEXT MAVLink message
+            await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Opening cargo compartment latch...')
+            sleep(3)
+        else:
+            print("\n[Custom Action Script ]  - Closing cargo compartment latch...\n")
+            await system.server_utility.send_status_text(StatusTextType.NOTICE, 'Closing cargo compartment latch...')
+            sleep(3)
+
+    except asyncio.TimeoutError:
+        global ret
+        ret = 1
+        print(
+            '[Custom Action Script ] Failed to connect to system after {} seconds. Action failed!'.format(args.timeout))
 
 
 if __name__ == '__main__':
     # Start the event loop
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(run())
+    try:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(run())
+    finally:
+        sys.exit(ret)

--- a/data/example/custom_action/custom_action_scripts/gimbal_controls.py
+++ b/data/example/custom_action/custom_action_scripts/gimbal_controls.py
@@ -50,6 +50,22 @@ from time import sleep
 from mavsdk import System
 from mavsdk.gimbal import ControlMode
 
+# Global return exit value
+ret = 0
+
+
+async def get_connection(system, ip_address, udp_port):
+    """Get connection."""
+    # Create a MAVLink connection to a system through a specific IP address
+    # and UDP port
+    await system.connect(system_address="udp://" + ip_address + ":" + udp_port)
+
+    print("[Custom Action Script ] Waiting for system to connect...")
+    async for state in system.core.connection_state():
+        if state.is_connected:
+            print(f"[Custom Action Script ] System discovered!")
+            break
+
 
 async def run() -> None:
     """Main funtion."""
@@ -61,6 +77,9 @@ async def run() -> None:
                         required=False)
     parser.add_argument('-p', '--port', dest='port', action="store",
                         help="mavlink-router UDP port", required=True)
+    parser.add_argument('-t', '--timeout', dest='timeout', action="store",
+                        help="Amount of time, in seconds, to wait for system connection",
+                        default=3.0, required=False, type=float)
     parser.add_argument(
         '--right', help="Change gimbal heading 90 degrees right", action="store_true")
     parser.add_argument(
@@ -71,47 +90,56 @@ async def run() -> None:
 
     # Init own system (1:MAV_COMP_ID_USER14)
     system = System(sysid=1, compid=38)
-    # Create a MAVLink connection to a system through a specific IP address
-    # and UDP port
-    await system.connect(system_address="udp://" + args.address + ":" + args.port)
 
-    print("[Custom Action Script ] Script: Waiting for system to connect...")
-    async for state in system.core.connection_state():
-        if state.is_connected:
-            print(f"[Custom Action Script ] Script: System discovered!")
-            break
+    # Wait for a system to be connected for X seconds
+    # If timeout, exit with error
+    try:
+        await asyncio.wait_for(get_connection(system, args.address, args.port), timeout=args.timeout)
 
-    if args.right:
-        print("\n[Custom Action Script ]  - Gimbal looking right for 3 seconds...\n")
-        # take control over gimbal
-        await system.gimbal.take_control(ControlMode.PRIMARY)
-        # control gimbal
-        await system.gimbal.set_pitch_and_yaw(0, 90)
-        sleep(3)
-        # release control
-        await system.gimbal.release_control()
+        if args.right:
+            print(
+                "\n[Custom Action Script ]  - Gimbal looking right for 3 seconds...\n")
+            # take control over gimbal
+            await system.gimbal.take_control(ControlMode.PRIMARY)
+            # control gimbal
+            await system.gimbal.set_pitch_and_yaw(0, 90)
+            sleep(3)
+            # release control
+            await system.gimbal.release_control()
 
-    elif args.left:
-        print("\n[Custom Action Script ]  - Gimbal looking left for 3 seconds...\n")
-        # take control over gimbal
-        await system.gimbal.take_control(ControlMode.PRIMARY)
-        # control gimbal
-        await system.gimbal.set_pitch_and_yaw(0, -90)
-        sleep(3)
-        # release control
-        await system.gimbal.release_control()
+        elif args.left:
+            print(
+                "\n[Custom Action Script ]  - Gimbal looking left for 3 seconds...\n")
+            # take control over gimbal
+            await system.gimbal.take_control(ControlMode.PRIMARY)
+            # control gimbal
+            await system.gimbal.set_pitch_and_yaw(0, -90)
+            sleep(3)
+            # release control
+            await system.gimbal.release_control()
 
-    elif args.down:
-        print("\n[Custom Action Script ]  - Gimbal looking down for 3 seconds...\n")
-        # take control over gimbal
-        await system.gimbal.take_control(ControlMode.PRIMARY)
-        # control gimbal
-        await system.gimbal.set_pitch_and_yaw(-90, 0)
-        sleep(3)
-        # release control
-        await system.gimbal.release_control()
+        elif args.down:
+            print(
+                "\n[Custom Action Script ]  - Gimbal looking down for 3 seconds...\n")
+            # take control over gimbal
+            await system.gimbal.take_control(ControlMode.PRIMARY)
+            # control gimbal
+            await system.gimbal.set_pitch_and_yaw(-90, 0)
+            sleep(3)
+            # release control
+            await system.gimbal.release_control()
+
+    except asyncio.TimeoutError:
+        global ret
+        ret = 1
+        print(
+            '[Custom Action Script ] Failed to connect to system after {} seconds. Action failed!'.format(args.timeout))
+
 
 if __name__ == '__main__':
     # Start the event loop
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(run())
+    try:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(run())
+    finally:
+        sys.exit(ret)

--- a/src/modules/mission_manager/CustomActionHandler.cpp
+++ b/src/modules/mission_manager/CustomActionHandler.cpp
@@ -33,7 +33,7 @@
 
 /**
  * @brief Custom Action Handler
- * @file CustomActionHandler.hpp
+ * @file CustomActionHandler.cpp
  * @author Nuno Marques <nuno@auterion.com>
  */
 
@@ -221,14 +221,16 @@ void CustomActionHandler::execute_custom_action(const mavsdk::CustomAction::Acti
                     } else if (action_metadata.stages[i].state_transition_condition ==
                                mavsdk::CustomAction::Stage::StateTransitionCondition::OnLandingComplete) {
                         // Wait for the vehicle to be landed
-                        while (!_action_stopped.load() && _landed_state == mavsdk::Telemetry::LandedState::Landing) {
+                        while (!_action_stopped.load() && (_landed_state == mavsdk::Telemetry::LandedState::Landing ||
+                                                           _landed_state != mavsdk::Telemetry::LandedState::OnGround)) {
                             std::this_thread::sleep_for(std::chrono::seconds(1));
                         }
 
                     } else if (action_metadata.stages[i].state_transition_condition ==
                                mavsdk::CustomAction::Stage::StateTransitionCondition::OnTakeoffComplete) {
                         // Wait for the vehicle to finish the takeoff
-                        while (!_action_stopped.load() && _landed_state == mavsdk::Telemetry::LandedState::TakingOff) {
+                        while (!_action_stopped.load() && (_landed_state == mavsdk::Telemetry::LandedState::TakingOff ||
+                                                           _landed_state != mavsdk::Telemetry::LandedState::InAir)) {
                             std::this_thread::sleep_for(std::chrono::seconds(1));
                         }
                     }


### PR DESCRIPTION
1. For some reason only check for TakingOff or Landing states is not enough to get a proper stage transition. Using now the InAir and OnGround states as well.
2. Improved scripts to handle the case where the a connection with a system doesn't happen. and so instead of blocking forever, it timeouts, allowing the custom action handler to proceed. Not though this is putting the timeout on the script side, instead of the handler side. **To robustify the handler, we need to add another transition condition to handle the return value of the script AND a timeout (and not just one or the other). For now, this is considered sufficient.**
3. Fix the case where the stage script would return an error but the ACK wouldn't be set to FAILED. This is now fixed by setting the stage execution call as synchronous and adding a small wait before cancelling the action (the the ACK sender thread has time to send at least one FAILED ack).