### PR TITLE
Add `px4_msgs` dependency in CI

### DIFF
--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - '*'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   packaging:
     name: "ROS 2 ${{ matrix.ros2_distro }} - ${{ matrix.arch }}"

--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -76,7 +76,7 @@ jobs:
           # Add source dependencies
           git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 /tmp/colcon_ws/src/eigen
           git clone git@github.com:Auterion/image_downsampler.git /tmp/colcon_ws/src/image_downsampler
-          git clone git@github.com:Auterion/landing_mapper.git -b develop /tmp/colcon_ws/src/landing_mapper
+          git clone git@github.com:Auterion/landing_mapper.git -b new-height-map /tmp/colcon_ws/src/landing_mapper
           git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
           git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
           git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools

--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -74,6 +74,7 @@ jobs:
           git clone git@github.com:Auterion/image_downsampler.git /tmp/colcon_ws/src/image_downsampler
           git clone git@github.com:Auterion/landing_mapper.git -b develop /tmp/colcon_ws/src/landing_mapper
           git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
+          git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
           git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools
           # Run cross-compilation
           ros_cross_compile /tmp/colcon_ws \
@@ -82,7 +83,7 @@ jobs:
             --rosdistro ${{ matrix.ros2_distro }} \
             --custom-setup-script scripts/cross_compile_dependencies.sh \
             --custom-data-dir /tmp/MAVSDK \
-            --skip-rosdep-keys Eigen3 image_downsampler landing_mapper landing_planner timing_tools \
+            --skip-rosdep-keys Eigen3 image_downsampler landing_mapper landing_planner px4_msgs timing_tools \
             --colcon-defaults /tmp/colcon_ws/src/autopilot_manager/scripts/packaging/defaults.yaml
       - name: Create zip
         run: |

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 colcon_ws/src/eigen
         git clone git@github.com:Auterion/image_downsampler.git colcon_ws/src/image_downsampler
-        git clone git@github.com:Auterion/landing_mapper.git -b develop colcon_ws/src/landing_mapper
+        git clone git@github.com:Auterion/landing_mapper.git -b new-height-map colcon_ws/src/landing_mapper
         git clone git@github.com:Auterion/landing_planner.git colcon_ws/src/landing_planner
         git clone git@github.com:Auterion/px4_msgs.git colcon_ws/src/px4_msgs
         git clone git@github.com:Auterion/timing_tools.git colcon_ws/src/timing_tools

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - '*'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: ROS 2 ${{ matrix.ros2_distro }}

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -68,6 +68,7 @@ jobs:
         git clone git@github.com:Auterion/image_downsampler.git colcon_ws/src/image_downsampler
         git clone git@github.com:Auterion/landing_mapper.git -b develop colcon_ws/src/landing_mapper
         git clone git@github.com:Auterion/landing_planner.git colcon_ws/src/landing_planner
+        git clone git@github.com:Auterion/px4_msgs.git colcon_ws/src/px4_msgs
         git clone git@github.com:Auterion/timing_tools.git colcon_ws/src/timing_tools
     - name: Check code formatting
       run: tools/check_code_format.sh
@@ -76,4 +77,4 @@ jobs:
         cd colcon_ws
         ln -s ${GITHUB_WORKSPACE} src/autopilot_manager
         source /opt/ros/${{ matrix.ros2_distro }}/setup.bash
-        colcon build
+        colcon build --event-handlers console_direct+

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -18,9 +18,10 @@ jobs:
   build:
     name: ROS 2 ${{ matrix.ros2_distro }}
     runs-on: ubuntu-20.04
+    container: px4io/px4-dev-ros2-${{ matrix.ros2_distro }}:2021-05-31
     strategy:
       matrix:
-        ros2_distro: [foxy, galactic]
+        ros2_distro: [foxy]
     steps:
     - uses: actions/checkout@v2
     - name: Disable the keychain credential helper
@@ -45,11 +46,8 @@ jobs:
         sudo sh -c 'echo "deb [arch=$(dpkg --print-architecture)] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2-latest.list'
         # Install ROS 2 ${{ matrix.ros2_distro }} packages
         sudo apt update
-        sudo apt install -y \
-          python3-colcon-common-extensions \
-          ros-${{ matrix.ros2_distro }}-ros-base \
+        sudo apt install -y --no-install-recommends \
           ros-${{ matrix.ros2_distro }}-sensor-msgs \
-          ros-${{ matrix.ros2_distro }}-image-pipeline \
           ros-${{ matrix.ros2_distro }}-visualization-msgs
         # Setup environment
         source /opt/ros/${{ matrix.ros2_distro }}/setup.bash
@@ -65,20 +63,22 @@ jobs:
         # Install Clang formatter
         sudo apt install -y clang-format-10
     - name: Create colcon workspace
-      run: mkdir -p colcon_ws/src
+      run: |
+        unset ROS_DISTRO
+        mkdir -p /tmp/colcon_ws/src
+        cp -ar ${GITHUB_WORKSPACE} /tmp/colcon_ws/src/autopilot_manager
     - name: Fetch source dependencies
       run: |
-        git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 colcon_ws/src/eigen
-        git clone git@github.com:Auterion/image_downsampler.git colcon_ws/src/image_downsampler
-        git clone git@github.com:Auterion/landing_mapper.git -b new-height-map colcon_ws/src/landing_mapper
-        git clone git@github.com:Auterion/landing_planner.git colcon_ws/src/landing_planner
-        git clone git@github.com:Auterion/px4_msgs.git colcon_ws/src/px4_msgs
-        git clone git@github.com:Auterion/timing_tools.git colcon_ws/src/timing_tools
+        git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 /tmp/colcon_ws/src/eigen
+        git clone git@github.com:Auterion/image_downsampler.git /tmp/colcon_ws/src/image_downsampler
+        git clone git@github.com:Auterion/landing_mapper.git -b new-height-map /tmp/colcon_ws/src/landing_mapper
+        git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
+        git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
+        git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools
     - name: Check code formatting
       run: tools/check_code_format.sh
     - name: Build
+      working-directory: /tmp/colcon_ws
       run: |
-        cd colcon_ws
-        ln -s ${GITHUB_WORKSPACE} src/autopilot_manager
         source /opt/ros/${{ matrix.ros2_distro }}/setup.bash
         colcon build --event-handlers console_direct+

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -75,8 +75,6 @@ jobs:
         git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
         git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
         git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools
-    - name: Check code formatting
-      run: tools/check_code_format.sh
     - name: Build
       working-directory: /tmp/colcon_ws
       run: |

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,0 +1,20 @@
+name: Check code style
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  check_code_style:
+    name: Check code style
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Check code style
+      run: tools/check_code_format.sh

--- a/src/modules/landing_manager/LandingManager.cpp
+++ b/src/modules/landing_manager/LandingManager.cpp
@@ -217,9 +217,10 @@ bool LandingManager::healthCheck(const std::shared_ptr<ExtendedDownsampledImageF
                 ss << " - Old timestamps (" << health.count_timestamp_old << ")";
             }
 
-            RCLCPP_ERROR(get_logger(), ss.str());
+            const std::string error_string = ss.str();
+            RCLCPP_ERROR(get_logger(), error_string.c_str());
             if (_server_utility) {
-                _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Alert, ss.str());
+                _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Alert, error_string);
             }
 
             last_warning = now;

--- a/src/modules/sensor_manager/CMakeLists.txt
+++ b/src/modules/sensor_manager/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(sensor-manager
   ${rclcpp_LIBRARIES}
   ${sensor_msgs_LIBRARIES}
   ${image_downsampler_LIBRARIES}
+  ${px4_msgs_LIBRARIES}
   ${timing_tools_LIBRARIES}
 )
 
@@ -63,7 +64,7 @@ target_link_libraries(sensor-manager
 ############
 
 # Export information to downstream packages
-ament_export_dependencies(ament_cmake rclcpp eigen3_cmake_module Eigen3 image_downsampler sensor_msgs tf2_ros)
+ament_export_dependencies(ament_cmake rclcpp eigen3_cmake_module Eigen3 image_downsampler sensor_msgs px4_msgs tf2_ros)
 ament_export_targets(export_sensor-manager HAS_LIBRARY_TARGET)
 
 ament_export_include_directories(include)

--- a/src/modules/sensor_manager/SensorManager.cpp
+++ b/src/modules/sensor_manager/SensorManager.cpp
@@ -298,9 +298,10 @@ void SensorManager::health_check() {
             ss << " - Images unhealthy.";
         }
 
-        RCLCPP_ERROR(get_logger(), ss.str());
+        const std::string error_string = ss.str();
+        RCLCPP_ERROR(get_logger(), error_string.c_str());
         if (_server_utility) {
-            _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Alert, ss.str());
+            _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Alert, error_string);
         }
     } else if (!health_reported_once) {
         health_reported_once = true;


### PR DESCRIPTION
`px4_msgs` was added as a dependency for the Sensor Manager, but the CI wasn't updated accordingly.

Adding `px4_msgs` also necessitated some other changes to ensure a working CI:
1. Using PX4's ROS2 container for the Ubuntu build.
2. Separating the code style check from the build check.
3. Specifying the default shell to be `bash`.
4. Using the `new-height-map` branch of `landing_mapper (which should be reverted once that becomes `master`).

#### Testing

Tested with this PR.
