### PR TITLE
Fix close-to-ground termination of landing site search

### DIFF
--- a/src/modules/mission_manager/MissionManager.cpp
+++ b/src/modules/mission_manager/MissionManager.cpp
@@ -563,7 +563,8 @@ void MissionManager::handle_safe_landing(std::chrono::time_point<std::chrono::sy
          */
         if (_landing_planner.isActive()) {
             if (_landed_state == mavsdk::Telemetry::LandedState::OnGround ||
-                safe_landing_state == LandingMapperState::CLOSE_TO_GROUND) {
+                (safe_landing_state == LandingMapperState::CLOSE_TO_GROUND &&
+                 _landing_planner.state() == landing_planner::LandingSearchState::ATTEMPTING_TO_LAND)) {
                 // Vehicle landed. Stop the landing site search.
                 std::cout << std::string(missionManagerOut) << "Vehicle landed or approaching ground." << std::endl;
                 _landing_planner.endSearch();


### PR DESCRIPTION
#### Description

During safe landing, it _occasionally_ happens that a landing is aborted just before the drone goes below the `CLOSE_TO_GROUND` altitude threshold. The landing _should_ abort as usual and the drone should ascend.

However, if it descends below the threshold just after aborting, the landing state becomes `CLOSE_TO_GROUND` and we end the landing site search. The drone still ascends and then tries to land again - which starts a whole new landing site search. This causes more landing attempts and changes the search pattern.

_The solution:_ only end the search when close to ground if the drone is still attempting to land and hasn't aborted the landing.

#### Test data / coverage

Tested in SITL by ensuring it did not interfere with a normal safe landing.

Quite hard to replicate the problem.