### PR TITLE
Fix which packages are included in binaries

### DIFF
--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Create zip
         run: |
           cd /tmp/colcon_ws/install_${{ matrix.arch }}
+          rm -rf px4_msgs # should be packaged in the px4-bridge
           zip -r autopilot-manager_${{ matrix.ros2_distro }}_v${{ steps.refs.outputs.tag_version }}_${{ steps.refs.outputs.package_arch }}.zip .
       - name: Publish artefacts
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -80,6 +80,11 @@ jobs:
           git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
           git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
           git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools
+          if [ ${{ matrix.ros2_distro }} == 'foxy' ]
+          then
+            git clone git@github.com:Auterion/ros2bagger.git /tmp/colcon_ws/src/ros2bagger
+            git clone git@github.com:ros2/rosbag2.git -b foxy-future /tmp/colcon_ws/src/rosbag2
+          fi
           # Run cross-compilation
           ros_cross_compile /tmp/colcon_ws \
             --arch ${{ matrix.arch }} \
@@ -87,7 +92,7 @@ jobs:
             --rosdistro ${{ matrix.ros2_distro }} \
             --custom-setup-script scripts/cross_compile_dependencies.sh \
             --custom-data-dir /tmp/MAVSDK \
-            --skip-rosdep-keys Eigen3 image_downsampler landing_mapper landing_planner px4_msgs timing_tools \
+            --skip-rosdep-keys Eigen3 image_downsampler landing_mapper landing_planner px4_msgs timing_tools ros2bagger rosbag2 \
             --colcon-defaults /tmp/colcon_ws/src/autopilot_manager/scripts/packaging/defaults.yaml
       - name: Create zip
         run: |

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -47,7 +47,9 @@ jobs:
         # Install ROS 2 ${{ matrix.ros2_distro }} packages
         sudo apt update
         sudo apt install -y --no-install-recommends \
+          ros-${{ matrix.ros2_distro }}-pybind11-vendor \
           ros-${{ matrix.ros2_distro }}-sensor-msgs \
+          ros-${{ matrix.ros2_distro }}-test-msgs \
           ros-${{ matrix.ros2_distro }}-visualization-msgs
         # Setup environment
         source /opt/ros/${{ matrix.ros2_distro }}/setup.bash
@@ -75,6 +77,11 @@ jobs:
         git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
         git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
         git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools
+        if [ ${{ matrix.ros2_distro }} == 'foxy' ]
+        then
+          git clone git@github.com:Auterion/ros2bagger.git /tmp/colcon_ws/src/ros2bagger
+          git clone git@github.com:ros2/rosbag2.git -b foxy-future /tmp/colcon_ws/src/rosbag2
+        fi
     - name: Build
       working-directory: /tmp/colcon_ws
       run: |

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ _Note: The host system is considered to run Ubuntu 20.04 Focal. Other OS's might
 ### ROS packages and workspace library dependencies
 
 1.  Auterion library packages:
+    - `image_downsampler`
     - `landing_mapper`
     - `landing_planner`
-    - `image_downsampler`
+    - `px4_msgs`
     - `timing_tools`
 2.  Eigen v3.3.9
+3.  If using ROS2 Foxy:
+    - Auterion `ros2bagger`
+    - [`rosbag2`](https://github.com/ros2/rosbag2) at `foxy-future`
 
 ### ROS 2 Foxy
 
@@ -149,9 +153,13 @@ git clone git@github.com:Auterion/autopilot_manager.git src/autopilot_manager
 # Clone the required dependencies
 git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 src/eigen
 git clone git@github.com:Auterion/image_downsampler.git src/image_downsampler
-git clone git@github.com:Auterion/landing_mapper.git -b develop src/landing_mapper
-git clone git@github.com:Auterion/landing_planner.git
-git clone git@github.com:Auterion/timing_tools.git
+git clone git@github.com:Auterion/landing_mapper.git src/landing_mapper
+git clone git@github.com:Auterion/landing_planner.git src/landing_planner
+git clone git@github.com:Auterion/px4_msgs.git src/px4_msgs
+git clone git@github.com:Auterion/timing_tools.git src/timing_tools
+# Only on ROS2 Foxy: clone data recording tools
+git clone git@github.com:Auterion/ros2bagger.git src/ros2bagger
+git clone git@github.com:ros2/rosbag2.git -b foxy-future src/rosbag2
 # Build with Release optimizations
 colcon build --cmake-force-configure --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
@@ -384,7 +392,7 @@ ros_cross_compile colcon_ws/src \
   --rosdistro foxy \
   --custom-setup-script colcon_ws/src/autopilot_manager/scripts/cross_compile_dependencies.sh \
   --custom-data-dir /tmp/MAVSDK \
-  --skip-rosdep-keys Eigen3 image_downsampler landing_mapper landing_planner timing_tools \
+  --skip-rosdep-keys Eigen3 image_downsampler landing_mapper landing_planner px4_msgs timing_tools ros2bagger rosbag2 \
   --colcon-defaults ~/colcon_ws/src/autopilot_manager/scripts/packaging/defaults.yaml
 ```
 


### PR DESCRIPTION
#### Describe your solution

This has two changes to the contents of the packaged binaries:

_1. Add ROS Bagger_
The new `ros2bagger` was not included in the CI build and was therefore not packaged in releases. This meant we could not record bags with the Autopilot Manager.
This ensures that the bagger is now packaged in releases.

_2. Remove `px4_msgs`_
We don't need `px4_msgs` in the Autopilot Manager binaries as it is installed as part of the `px4-bridge` binaries instead.

#### Test data / coverage
This PR

---

**Jira Task:** [AVOID-274](https://auterion.atlassian.net/browse/AVOID-274) (also #45)

#### Does this PR need to be backported to the stable release?
Yes, to v1.2.0 (or just create a new release v1.2.1)

#### Does this PR need to update any documentation (readme, confluence, gitbook, etc.)?
No
