### PR TITLE
Create .rosinstall

### DIFF
--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -60,6 +60,7 @@ jobs:
           sudo apt update && sudo apt install -y --no-install-recommends \
             git \
             python3-pip \
+            python3-rosinstall \
             qemu-user-static
           sudo pip3 install ros_cross_compile
       - name: Configure workspace
@@ -67,24 +68,21 @@ jobs:
           unset ROS_DISTRO
           mkdir -p /tmp/colcon_ws/src
           cp -ar ${GITHUB_WORKSPACE} /tmp/colcon_ws/src/autopilot_manager/
-      - name: Fetch source dependencies
+      - name: Clone MAVSDK
         run: |
           # Clone MAVSDK to be built from source
           git clone --recursive https://github.com/Auterion/MAVSDK.git -b main /tmp/MAVSDK
           # Add COLCON_IGNORE to the MAVSDK dir so colcon doesn't build it
           touch /tmp/MAVSDK/COLCON_IGNORE
-          # Add source dependencies
-          git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 /tmp/colcon_ws/src/eigen
-          git clone git@github.com:Auterion/image_downsampler.git /tmp/colcon_ws/src/image_downsampler
-          git clone git@github.com:Auterion/landing_mapper.git /tmp/colcon_ws/src/landing_mapper
-          git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
-          git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
-          git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools
-          if [ ${{ matrix.ros2_distro }} == 'foxy' ]
+      - name: Fetch source dependencies
+        working-directory: /tmp/colcon_ws/src/autopilot_manager
+        run: |
+          if [ ${{ matrix.ros2_distro }} == 'galactic' ]
           then
-            git clone git@github.com:Auterion/ros2bagger.git /tmp/colcon_ws/src/ros2bagger
-            git clone git@github.com:ros2/rosbag2.git -b foxy-future /tmp/colcon_ws/src/rosbag2
+            cp .rosinstall.galactic .rosinstall
+            echo "Using source dependencies for ROS2 Galactic"
           fi
+          rosws update -t .
       - name: Setup source dependencies in develop mode
         if: github.event_name == 'pull_request' && github.base_ref != 'main'
         run: |

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -47,6 +47,7 @@ jobs:
         # Install ROS 2 ${{ matrix.ros2_distro }} packages
         sudo apt update
         sudo apt install -y --no-install-recommends \
+          python3-rosinstall \
           ros-${{ matrix.ros2_distro }}-pybind11-vendor \
           ros-${{ matrix.ros2_distro }}-sensor-msgs \
           ros-${{ matrix.ros2_distro }}-test-msgs \
@@ -70,18 +71,14 @@ jobs:
         mkdir -p /tmp/colcon_ws/src
         cp -ar ${GITHUB_WORKSPACE} /tmp/colcon_ws/src/autopilot_manager
     - name: Fetch source dependencies
+      working-directory: /tmp/colcon_ws/src/autopilot_manager
       run: |
-        git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 /tmp/colcon_ws/src/eigen
-        git clone git@github.com:Auterion/image_downsampler.git /tmp/colcon_ws/src/image_downsampler
-        git clone git@github.com:Auterion/landing_mapper.git /tmp/colcon_ws/src/landing_mapper
-        git clone git@github.com:Auterion/landing_planner.git /tmp/colcon_ws/src/landing_planner
-        git clone git@github.com:Auterion/px4_msgs.git /tmp/colcon_ws/src/px4_msgs
-        git clone git@github.com:Auterion/timing_tools.git /tmp/colcon_ws/src/timing_tools
-        if [ ${{ matrix.ros2_distro }} == 'foxy' ]
+        if [ ${{ matrix.ros2_distro }} == 'galactic' ]
         then
-          git clone git@github.com:Auterion/ros2bagger.git /tmp/colcon_ws/src/ros2bagger
-          git clone git@github.com:ros2/rosbag2.git -b foxy-future /tmp/colcon_ws/src/rosbag2
+          cp .rosinstall.galactic .rosinstall
+          echo "Using source dependencies for ROS2 Galactic"
         fi
+        rosws update -t .
     - name: Setup source dependencies in develop mode
       if: github.event_name == 'pull_request' && github.base_ref != 'main'
       run: |

--- a/.rosinstall
+++ b/.rosinstall
@@ -1,0 +1,34 @@
+# Source dependencies for the ROS2 Foxy workspace
+
+- git:
+    local-name: ../eigen
+    uri: 'https://gitlab.com/libeigen/eigen.git'
+    version: 3.3.9
+- git:
+    local-name: ../image_downsampler
+    uri: 'git@github.com:Auterion/image_downsampler.git'
+    version: develop
+- git:
+    local-name: ../landing_mapper
+    uri: 'git@github.com:Auterion/landing_mapper.git'
+    version: master
+- git:
+    local-name: ../landing_planner
+    uri: 'git@github.com:Auterion/landing_planner.git'
+    version: master
+- git:
+    local-name: ../px4_msgs
+    uri: 'git@github.com:Auterion/px4_msgs.git'
+    version: develop
+- git:
+    local-name: ../timing_tools
+    uri: 'git@github.com:Auterion/timing_tools.git'
+    version: master
+- git:
+    local-name: ../ros2bagger
+    uri: 'git@github.com:Auterion/ros2bagger.git'
+    version: master
+- git:
+    local-name: ../rosbag2
+    uri: 'git@github.com:ros2/rosbag2.git'
+    version: foxy-future

--- a/.rosinstall.galactic
+++ b/.rosinstall.galactic
@@ -1,0 +1,26 @@
+# Source dependencies for the ROS2 Galactic workspace
+
+- git:
+    local-name: ../eigen
+    uri: 'https://gitlab.com/libeigen/eigen.git'
+    version: 3.3.9
+- git:
+    local-name: ../image_downsampler
+    uri: 'git@github.com:Auterion/image_downsampler.git'
+    version: develop
+- git:
+    local-name: ../landing_mapper
+    uri: 'git@github.com:Auterion/landing_mapper.git'
+    version: master
+- git:
+    local-name: ../landing_planner
+    uri: 'git@github.com:Auterion/landing_planner.git'
+    version: master
+- git:
+    local-name: ../px4_msgs
+    uri: 'git@github.com:Auterion/px4_msgs.git'
+    version: develop
+- git:
+    local-name: ../timing_tools
+    uri: 'git@github.com:Auterion/timing_tools.git'
+    version: master

--- a/README.md
+++ b/README.md
@@ -148,21 +148,17 @@ source /opt/ros/foxy/setup.bash
 # Create colcon workspace
 mkdir -p colcon_ws/src
 cd colcon_ws
-# Clone the autopilot-manager package
+# Clone the autopilot_manager package
 git clone git@github.com:Auterion/autopilot_manager.git src/autopilot_manager
 # Clone the required dependencies
-git clone https://gitlab.com/libeigen/eigen.git -b 3.3.9 src/eigen
-git clone git@github.com:Auterion/image_downsampler.git src/image_downsampler
-git clone git@github.com:Auterion/landing_mapper.git src/landing_mapper
-git clone git@github.com:Auterion/landing_planner.git src/landing_planner
-git clone git@github.com:Auterion/px4_msgs.git src/px4_msgs
-git clone git@github.com:Auterion/timing_tools.git src/timing_tools
-# Only on ROS2 Foxy: clone data recording tools
-git clone git@github.com:Auterion/ros2bagger.git src/ros2bagger
-git clone git@github.com:ros2/rosbag2.git -b foxy-future src/rosbag2
+cd src/autopilot_manager
+rosws update -t .
 # Build with Release optimizations
+cd ../../
 colcon build --cmake-force-configure --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
+
+_Note:_ If using ROS2 Galactic, replace `.rosinstall` with `.rosinstall.galactic` before running `rosws`.
 
 #### Installing private repos
 


### PR DESCRIPTION
#### Describe your solution

Use a `.rosinstall` file to define the source dependencies and versions.

The Autopilot Manager workspace could now be setup and built from scratch with:

```bash
mkdir -p ~/colcon_ws/src
cd ~/colcon_ws/src
git clone git@github.com:Auterion/autopilot_manager.git
cd autopilot_manager
rosws update -t .
cd ../../
colcon build
```

All source dependencies will have been checked out into `~/colcon_ws/src`.

_If using ROS2 Galactic:_
The file `.rosinstall` must be replaced with `.rosinstall.galactic`. This will exclude the ROS bagging repos, which only work in Foxy.

#### Test data / coverage

- [x] Local install & build
- [x] CI install and build (with this PR)

---

**Jira Task:** [AVOID-275](https://auterion.atlassian.net/browse/AVOID-275)

#### Does this PR need to be backported to the stable release?
No

#### Does this PR need to update any documentation (readme, confluence, gitbook, etc.)?
Yes: updated install instructions in readme.