### PR TITLE
Adapt to Landing Planner interface changes

### DIFF
--- a/.github/workflows/build_pkg_multi_arch.yml
+++ b/.github/workflows/build_pkg_multi_arch.yml
@@ -67,7 +67,7 @@ jobs:
           unset ROS_DISTRO
           mkdir -p /tmp/colcon_ws/src
           cp -ar ${GITHUB_WORKSPACE} /tmp/colcon_ws/src/autopilot_manager/
-      - name: Build & Packaging (autopilot_manager)
+      - name: Fetch source dependencies
         run: |
           # Clone MAVSDK to be built from source
           git clone --recursive https://github.com/Auterion/MAVSDK.git -b main /tmp/MAVSDK
@@ -85,6 +85,16 @@ jobs:
             git clone git@github.com:Auterion/ros2bagger.git /tmp/colcon_ws/src/ros2bagger
             git clone git@github.com:ros2/rosbag2.git -b foxy-future /tmp/colcon_ws/src/rosbag2
           fi
+      - name: Setup source dependencies in develop mode
+        if: github.event_name == 'pull_request' && github.base_ref != 'main'
+        run: |
+          echo "Setting up develop-mode sources for PR to branch ${{ github.base_ref }}"
+          # Landing Mapper
+          cd /tmp/colcon_ws/src/landing_mapper
+          git checkout develop
+          cd -
+      - name: Build
+        run: |
           # Run cross-compilation
           ros_cross_compile /tmp/colcon_ws \
             --arch ${{ matrix.arch }} \

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -82,6 +82,14 @@ jobs:
           git clone git@github.com:Auterion/ros2bagger.git /tmp/colcon_ws/src/ros2bagger
           git clone git@github.com:ros2/rosbag2.git -b foxy-future /tmp/colcon_ws/src/rosbag2
         fi
+    - name: Setup source dependencies in develop mode
+      if: github.event_name == 'pull_request' && github.base_ref != 'main'
+      run: |
+        echo "Setting up develop-mode sources for PR to branch ${{ github.base_ref }}"
+        # Landing Mapper
+        cd /tmp/colcon_ws/src/landing_mapper
+        git checkout develop
+        cd -
     - name: Build
       working-directory: /tmp/colcon_ws
       run: |


### PR DESCRIPTION
#### Describe your solution

Adapt to the updated logic of the Landing Planner in:
- https://github.com/Auterion/landing_planner/pull/8

This moves a lot of the search-progression logic into the planner, simplifying the usage in the Autopilot Manager.

#### Test data / coverage

Tested in SITL with land commands and interrupted landings.

- [x] Laptop / SITL
- [ ] Skynode

---

**Jira Task:** [AVOID-280](https://auterion.atlassian.net/browse/AVOID-280)

**Does this PR need to be backported to the stable release?** No

**Does this PR need to update any documentation (readme, confluence, gitbook, etc.)?** No