### PR TITLE
Actually use the landing speeds from PX4 in safe landing

### DIFF
--- a/src/modules/mission_manager/MissionManager.cpp
+++ b/src/modules/mission_manager/MissionManager.cpp
@@ -151,9 +151,9 @@ void MissionManager::on_mavlink_trajectory_message(const mavlink_message_t& _mes
 
             // Determine landing speed
             const float height_above_obstacle = _height_above_obstacle_update_callback();
-            float land_velocity = 0.7;
-            if (height_above_obstacle < 1.) {
-                land_velocity = 0.3;
+            float land_velocity = _landing_speed;
+            if (height_above_obstacle < _landing_crawl_altitude) {
+                land_velocity = _landing_crawl_speed;
             }
 
             // Command the landing speed and position


### PR DESCRIPTION
#### Describe your solution

In #51 we made the PX4 parameters that determine the landing speed available in the Mission Manager. However, we didn't actually use them for safe landings. Now we do.

#### Test data / coverage
Tested in SITL.

---

**Jira Task:** [AVOID-276](https://auterion.atlassian.net/browse/AVOID-276)

#### Does this PR need to be backported to the stable release?
No

#### Does this PR need to update any documentation (readme, confluence, gitbook, etc.)?
No