### PR TITLE
Don't perform health checks on depth images when disabled

### DIFF
--- a/include/AutopilotManager.hpp
+++ b/include/AutopilotManager.hpp
@@ -19,6 +19,8 @@
 #include <mission_manager/MissionManager.hpp>
 #include <sensor_manager/SensorManager.hpp>
 
+static constexpr auto autopilotManagerOut = "[Autopilot Manager] ";
+
 class AutopilotManager {
    public:
     AutopilotManager(const std::string& mavlinkPort, const std::string& configPath,
@@ -44,9 +46,15 @@ class AutopilotManager {
     void run_sensor_manager();
     void run_collision_avoidance_manager();
     void run_landing_manager();
+    void run_mission_manager();
+
+    void run();
+    void update_obstacle_avoidance_enabled();
 
     auto SetConfiguration(AutopilotManagerConfig config) -> ResponseCode;
     auto GetConfiguration(AutopilotManagerConfig config) -> ResponseCode;
+
+    std::atomic<bool> _obstacle_avoidance_enabled;
 
     uint8_t _autopilot_manager_enabled = false;
     std::string _decision_maker_input_type = "";
@@ -100,6 +108,7 @@ class AutopilotManager {
     std::thread _sensor_manager_th;
     std::thread _landing_manager_th;
     std::thread _collision_avoidance_manager_th;
+    std::thread _mission_manager_th;
 
     std::shared_ptr<MissionManager> _mission_manager;
     std::shared_ptr<SensorManager> _sensor_manager;
@@ -117,6 +126,10 @@ class AutopilotManager {
     std::string _custom_action_config_path =
         "/usr/src/app/autopilot-manager/data/example/custom_action/custom_action.json";
 
+    std::shared_ptr<mavsdk::Param> _param;
+
     static constexpr uint8_t kDefaultSystemId = 1;
     static constexpr uint8_t kMavCompIDOnBoardComputer3 = 193;
+
+    std::atomic<bool> _interrupt_received{false};
 };

--- a/src/AutopilotManager.cpp
+++ b/src/AutopilotManager.cpp
@@ -480,4 +480,6 @@ void AutopilotManager::update_obstacle_avoidance_enabled() {
 
     // Update the modules that use the OA-enabled parameter
     _mission_manager->set_obstacle_avoidance_enabled(_obstacle_avoidance_enabled);
+    _landing_manager->set_obstacle_avoidance_enabled(_obstacle_avoidance_enabled);
+    _sensor_manager->set_obstacle_avoidance_enabled(_obstacle_avoidance_enabled);
 }

--- a/src/modules/ObstacleAvoidanceModule.hpp
+++ b/src/modules/ObstacleAvoidanceModule.hpp
@@ -1,0 +1,52 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2022 Auterion AG. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name Auterion nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @brief A module that uses, or is reliant on, obstacle avoidance.
+ * @file ObstacleAvoidanceModule.hpp
+ * @author Daniel Mesham <daniel@auterion.com>
+ */
+
+#pragma once
+
+#include <atomic>
+
+class ObstacleAvoidanceModule {
+   public:
+    void set_obstacle_avoidance_enabled(const bool enabled) { _oa_enabled = enabled; };
+
+    bool obstacle_avoidance_is_enabled() { return _oa_enabled; };
+
+   private:
+    std::atomic<bool> _oa_enabled{false};
+};

--- a/src/modules/landing_manager/LandingManager.cpp
+++ b/src/modules/landing_manager/LandingManager.cpp
@@ -255,9 +255,13 @@ void LandingManager::mapper() {
 
     // TODO: reinstantiate _mapper a after parameter update
 
-    // Only process the data when the Autopilot Manager is enabled and the Safe Landing
-    // is set as the Decision Maker Input.
-    if (_landing_manager_config.autopilot_manager_enabled && _landing_manager_config.safe_landing_enabled) {
+    // Only process the data to build a landing map when the Autopilot Manager is enabled, Safe Landing is set as the
+    // decision maker, and the OA interface is enabled (i.e. the user has activated Safe Landing).
+    const bool should_build_landing_map = _landing_manager_config.autopilot_manager_enabled &&
+                                          _landing_manager_config.safe_landing_enabled &&
+                                          obstacle_avoidance_is_enabled();
+
+    if (should_build_landing_map) {
         timing_tools::Timer timer_mapper("mapper: total", true);
 
         // Here we capture the downsampled depth data computed in the SensorManager

--- a/src/modules/landing_manager/LandingManager.hpp
+++ b/src/modules/landing_manager/LandingManager.hpp
@@ -45,6 +45,7 @@
 
 #include <Eigen/Core>
 #include <ModuleBase.hpp>
+#include <ObstacleAvoidanceModule.hpp>
 #include <chrono>
 #include <iostream>
 
@@ -70,7 +71,7 @@ struct VehicleState {
 
 static constexpr auto landingManagerOut = "[Landing Manager] ";
 
-class LandingManager : public rclcpp::Node, ModuleBase {
+class LandingManager : public rclcpp::Node, public ObstacleAvoidanceModule, ModuleBase {
    public:
     LandingManager(std::shared_ptr<mavsdk::System> mavsdk_system);
     ~LandingManager();

--- a/src/modules/mission_manager/MissionManager.hpp
+++ b/src/modules/mission_manager/MissionManager.hpp
@@ -45,6 +45,7 @@
 #include <Eigen/Eigen>
 #include <Eigen/Geometry>
 #include <ModuleBase.hpp>
+#include <ObstacleAvoidanceModule.hpp>
 #include <atomic>
 #include <future>
 #include <iostream>
@@ -68,7 +69,7 @@
 
 static constexpr auto missionManagerOut = "[Mission Manager] ";
 
-class MissionManager : public rclcpp::Node, ModuleBase {
+class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, ModuleBase {
    public:
     MissionManager(std::shared_ptr<mavsdk::System> mavsdk_system, const std::string& path_to_custom_action_file);
     ~MissionManager();
@@ -174,7 +175,6 @@ class MissionManager : public rclcpp::Node, ModuleBase {
     bool under_manual_control();
 
     void update_landing_speed_config();
-    void update_obstacle_avoidance_enabled();
 
     mavsdk::geometry::CoordinateTransformation::LocalCoordinate get_local_position_from_local_offset(
         const double& offset_x, const double& offset_y) const;
@@ -250,7 +250,6 @@ class MissionManager : public rclcpp::Node, ModuleBase {
     rclcpp::Time _time_last_traj;
 
     std::atomic<bool> _got_traj;
-    std::atomic<bool> _obstacle_avoidance_enabled;
 
     timing_tools::FrequencyMeter _frequency_traj;
 

--- a/src/modules/sensor_manager/SensorManager.cpp
+++ b/src/modules/sensor_manager/SensorManager.cpp
@@ -273,6 +273,11 @@ void SensorManager::health_check() {
         return;
     }
 
+    // Do nothing if OA interface is not enabled
+    if (!obstacle_avoidance_is_enabled()) {
+        return;
+    }
+
     const auto s_since_last_odom = (now - _time_last_odometry).seconds();
     const auto s_since_last_image = (now - _time_last_image).seconds();
 

--- a/src/modules/sensor_manager/SensorManager.hpp
+++ b/src/modules/sensor_manager/SensorManager.hpp
@@ -45,6 +45,7 @@
 
 #include <Eigen/Dense>
 #include <ModuleBase.hpp>
+#include <ObstacleAvoidanceModule.hpp>
 #include <chrono>
 #include <iomanip>
 #include <iostream>
@@ -75,7 +76,7 @@
 
 inline static constexpr auto sensorManagerOut = "[Sensor Manager] ";
 
-class SensorManager : public rclcpp::Node, ModuleBase {
+class SensorManager : public rclcpp::Node, public ObstacleAvoidanceModule, ModuleBase {
    public:
     SensorManager(std::shared_ptr<mavsdk::System> mavsdk_system);
     ~SensorManager();


### PR DESCRIPTION
### Problem

If the Autopilot Manager is installed and running, the _Sensor Manager_ and _Landing Manager_ still perform health checks on the depth image stream. If the RealSense is not connected, this will cause the user to receive a constant stream of error messages in AMC.

Going forward, we want to have safe landing installed and ready to use in AOS, which means Autopilot Manager will be running. However, when a user is not planning to use safe landing (no RealSense connected and `COM_OBS_AVOID` set to 0), they should not be aware of it and should definitely not receive errors.

### Changes

- _Landing Manager_ only builds the map  (which includes the health check) when OA is enabled.
- _Sensor Manager_ only runs the health check when OA is enabled.


#### Preferred alternative:

It would be better if this were slightly more configurable for the user. The `COM_OBS_AVOID` parameter is too non-specific.
There should be a user-accessible parameter (AMC) to explicitly disable _safe landing_, which would then completely stop the Autopilot Manager service or, at the very least, put it into a "standby"/"not active" mode.

### Not addressed by this change

When images are unhealthy while OA is enabled, the user will still be spammed by messages.
The drone will still arm and fly, and only Safe Landing will be prevented because of the missing data.

Future work should probably look at preventing arming when images are unhealthy and OA is enabled - if we think that's a sensible pre-arm condition.

### Test data / coverage

- [x] SITL (use model without the depth camera and get no errors)
- [x] Skynode

---

**Jira Task:** [AVOID-287](https://auterion.atlassian.net/browse/AVOID-287)
**Backport needed?** No
**Documentation needed?** No
