### PR TITLE
Only send avoidance heartbeat when Safe Landing is fully enabled

### DIFF
--- a/include/AutopilotManager.hpp
+++ b/include/AutopilotManager.hpp
@@ -2,6 +2,7 @@
 
 #include <dbus/dbus.h>
 #include <mavsdk/mavsdk.h>
+#include <mavsdk/plugins/mavlink_passthrough/mavlink_passthrough.h>
 #include <mavsdk/plugins/param/param.h>
 
 #include <AutopilotManagerConfig.hpp>
@@ -52,10 +53,14 @@ class AutopilotManager {
     void run();
     void update_obstacle_avoidance_enabled();
 
+    void create_avoidance_mavlink_heartbeat_message();
+
     auto SetConfiguration(AutopilotManagerConfig config) -> ResponseCode;
     auto GetConfiguration(AutopilotManagerConfig config) -> ResponseCode;
 
     std::atomic<bool> _obstacle_avoidance_enabled;
+
+    mavlink_message_t _avoidance_heartbeat_message;
 
     uint8_t _autopilot_manager_enabled = false;
     std::string _decision_maker_input_type = "";
@@ -127,6 +132,7 @@ class AutopilotManager {
     std::string _custom_action_config_path =
         "/usr/src/app/autopilot-manager/data/example/custom_action/custom_action.json";
 
+    std::shared_ptr<mavsdk::MavlinkPassthrough> _mavlink_passthrough;
     std::shared_ptr<mavsdk::Param> _param;
 
     static constexpr uint8_t kDefaultSystemId = 1;

--- a/src/AutopilotManager.cpp
+++ b/src/AutopilotManager.cpp
@@ -457,9 +457,10 @@ void AutopilotManager::run() {
         // Send avoidance heartbeat
         if (_obstacle_avoidance_enabled) {
             const bool sm_healthy = _sensor_manager->isHealthy();
+            const bool lm_healthy = _landing_manager->isHealthy();
             const bool mm_healthy = _mission_manager->isHealthy();
 
-            if (sm_healthy && mm_healthy) {
+            if (sm_healthy && lm_healthy && mm_healthy) {
                 _mavlink_passthrough->send_message(_avoidance_heartbeat_message);
             }
         }

--- a/src/modules/landing_manager/LandingManager.hpp
+++ b/src/modules/landing_manager/LandingManager.hpp
@@ -118,11 +118,20 @@ class LandingManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
     bool setSearchAltitude_m(double altitude_m);
     bool setSearchWindow_m(double window_size_m);
 
+    bool isHealthy() const { return _health_status == HealthStatus::HEALTHY; }
+
    private:
+    enum HealthStatus {
+        HEALTHY = 0,
+        UNHEALTHY_NULL_IMAGES = 1,
+        UNHEALTHY_OLD_TIMESTAMPS = 2,
+        UNHEALTHY_NULL_IMAGES_AND_OLD_TIMESTAMPS = 3
+    };
+
     void initParameters();
     void updateParameters();
     void mapper();
-    bool healthCheck(const std::shared_ptr<ExtendedDownsampledImageF>& depth_msg) const;
+    bool healthCheck(const std::shared_ptr<ExtendedDownsampledImageF>& depth_msg);
 
     void publishHeightStats(const height_map::HeightMapStats& height_stats) const;
 
@@ -155,6 +164,8 @@ class LandingManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
 
     rclcpp::TimerBase::SharedPtr _timer_mapper;
     rclcpp::TimerBase::SharedPtr _timer_map_visualizer;
+
+    HealthStatus _health_status;
 
     int _images_processed = 0;
     int _points_processed = 0;

--- a/src/modules/mission_manager/MissionManager.cpp
+++ b/src/modules/mission_manager/MissionManager.cpp
@@ -47,6 +47,9 @@
 using namespace std::placeholders;
 using namespace std::chrono_literals;
 
+static constexpr auto decision_maker_run_interval = 50ms;
+static constexpr auto gps_origin_update_interval = 1s;
+
 static std::atomic<bool> int_signal{false};
 
 using LandingMapperState = landing_mapper::eLandingMapperState;
@@ -322,7 +325,7 @@ void MissionManager::set_global_position_reference() {
         if (status != "") {
             std::cout << status << std::endl;
         }
-        std::this_thread::sleep_for(1s);
+        std::this_thread::sleep_for(gps_origin_update_interval);
     }
 }
 
@@ -1018,9 +1021,7 @@ void MissionManager::decision_maker_run() {
                 std::cout << missionManagerOut << "5 seconds have passed since last action." << std::endl;
             }
         }
-
-        // Decision maker runs at 20hz
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(decision_maker_run_interval);
     }
 
     _is_healthy = false;

--- a/src/modules/mission_manager/MissionManager.cpp
+++ b/src/modules/mission_manager/MissionManager.cpp
@@ -78,6 +78,7 @@ MissionManager::MissionManager(std::shared_ptr<mavsdk::System> mavsdk_system,
       _previously_set_waypoint_longitude{0.0},
       _previously_set_waypoint_altitude_amsl{0.0},
       _landing_planner{},
+      _time_last_heartbeat{this->now()},
       _time_last_traj{this->now()},
       _got_traj{true},
       _frequency_traj("traj in") {}
@@ -103,6 +104,9 @@ void MissionManager::init() {
 
     _custom_action_handler =
         std::make_shared<CustomActionHandler>(_mavsdk_system, _telemetry, _path_to_custom_action_file);
+
+    // Create reusable heartbeat message
+    create_avoidance_mavlink_heartbeat_message();
 }
 
 void MissionManager::deinit() {
@@ -131,12 +135,21 @@ void MissionManager::run() {
     rclcpp::spin(shared_from_this());
 }
 
-void MissionManager::send_avoidance_mavlink_heartbeat() {
-    mavlink_message_t new_heartbeat_message;
+void MissionManager::create_avoidance_mavlink_heartbeat_message() {
     mavlink_heartbeat_t heartbeat;
     heartbeat.system_status = MAV_STATE_ACTIVE;
-    mavlink_msg_heartbeat_encode(1, MAV_COMP_ID_OBSTACLE_AVOIDANCE, &new_heartbeat_message, &heartbeat);
-    _mavlink_passthrough->send_message(new_heartbeat_message);
+    mavlink_msg_heartbeat_encode(1, MAV_COMP_ID_OBSTACLE_AVOIDANCE, &_oa_heartbeat_message, &heartbeat);
+}
+
+void MissionManager::send_avoidance_mavlink_heartbeat() {
+    const auto time_now = this->get_clock()->now();
+    const auto s_since_last_heartbeat = (time_now - _time_last_heartbeat).seconds();
+
+    // Send heartbeat at 5Hz
+    if (s_since_last_heartbeat >= 0.2f) {
+        _mavlink_passthrough->send_message(_oa_heartbeat_message);
+        _time_last_heartbeat = time_now;
+    }
 }
 
 void MissionManager::on_mavlink_trajectory_message(const mavlink_message_t& _message) {

--- a/src/modules/mission_manager/MissionManager.cpp
+++ b/src/modules/mission_manager/MissionManager.cpp
@@ -508,77 +508,192 @@ void MissionManager::handle_safe_landing(std::chrono::time_point<std::chrono::sy
      * If we're not handling an action already and landing has been triggered, check if we need to start the safe
      * landing action.
      */
-    if (!_action_triggered) {
+    if (!_action_triggered && landing_triggered()) {
         std::string status{};
 
-        if (!obstacle_avoidance_is_enabled()) {
-            // If no actions are currently in progress and OA is disabled, do nothing for safe landing.
-            // If OA is disabled, actions will still be processed.
-            return;
-        }
+        /*
+         *  Stop landing and hold if
+         *      1. vehicle is >1.5m above ground and mapper is "unhealthy"
+         *  Start safe landing if
+         *      1. mapper says "cannot land", or
+         *      2. mapper has no data ("unknown") and vehicle is still >1.5m above ground
+         *  Land without intervention if
+         *      1. mapper says "can land", "too high" or "close to ground", or
+         *      2. mapper is "unhealthy" or "unknown" but vehicle is already near the ground (<=1.5m)
+         */
+        const bool cannot_land = safe_landing_state == LandingMapperState::CAN_NOT_LAND;
+        const bool unhealthy_and_above_1_5m =
+            safe_landing_state == LandingMapperState::UNHEALTHY && height_above_obstacle > 1.5;
+        const bool unknown_and_above_1_5m =
+            safe_landing_state == LandingMapperState::UNKNOWN && height_above_obstacle > 1.5;
+        const bool should_trigger_safe_landing = cannot_land || unknown_and_above_1_5m;
+        if (unhealthy_and_above_1_5m) {
+            // If the safe landing status is unhealthy, then hold position.
+            _action->hold();
 
-        if (landing_triggered()) {
-            /*
-             *  Stop landing and hold if
-             *      1. vehicle is >1.5m above ground and mapper is "unhealthy"
-             *  Start safe landing if
-             *      1. mapper says "cannot land", or
-             *      2. mapper has no data ("unknown") and vehicle is still >1.5m above ground
-             *  Land without intervention if
-             *      1. mapper says "can land", "too high" or "close to ground", or
-             *      2. mapper is "unhealthy" or "unknown" but vehicle is already near the ground (<=1.5m)
-             */
-            const bool cannot_land = safe_landing_state == LandingMapperState::CAN_NOT_LAND;
-            const bool unhealthy_and_above_1_5m =
-                safe_landing_state == LandingMapperState::UNHEALTHY && height_above_obstacle > 1.5;
-            const bool unknown_and_above_1_5m =
-                safe_landing_state == LandingMapperState::UNKNOWN && height_above_obstacle > 1.5;
-            const bool should_trigger_safe_landing = cannot_land || unknown_and_above_1_5m;
-            if (unhealthy_and_above_1_5m) {
-                // If the safe landing status is unhealthy, then hold position.
+            status = std::string(missionManagerOut) + "Safe landing system not healthy. Holding position...";
+            _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
+            std::cout << status << std::endl;
+
+            _action_triggered = true;
+            _last_time = now;
+        } else if (should_trigger_safe_landing) {
+            std::cout << std::string(missionManagerOut) << "Cannot land! ----------------------- ("
+                      << safe_landing_state << ")" << std::endl;
+            if (safe_landing_on_no_safe_land == "HOLD") {
                 _action->hold();
 
-                status = std::string(missionManagerOut) + "Safe landing system not healthy. Holding position...";
+                status = std::string(missionManagerOut) + "Position hold triggered for Safe Landing";
+                _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Info, status);
+                std::cout << status << std::endl;
+
+            } else if (safe_landing_on_no_safe_land == "RTL") {
+                _action->return_to_launch();
+
+                status = std::string(missionManagerOut) + "RTL triggered for Safe Landing";
+                _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Info, status);
+                std::cout << status << std::endl;
+
+            } else if (safe_landing_on_no_safe_land == "MOVE_XYZ_WRT_CURRENT") {
+                // get the global origin from the FMU and set the reference
+                if (_global_origin_reference_set) {
+                    const auto waypoint =
+                        get_global_position_from_local_offset(local_position_offset_x, local_position_offset_y);
+                    const double waypoint_altitude = _current_altitude_amsl + local_position_offset_z;
+
+                    _action->goto_location(waypoint.latitude_deg, waypoint.longitude_deg, waypoint_altitude, NAN);
+
+                    set_new_waypoint(waypoint.latitude_deg, waypoint.longitude_deg, waypoint_altitude);
+
+                    status = std::string(missionManagerOut) +
+                             "Moving XYZ WRT to current vehicle position triggered for Safe Landing. Heading to "
+                             "determined "
+                             "Latitude " +
+                             std::to_string(waypoint.latitude_deg) + " deg, Longitude " +
+                             std::to_string(waypoint.longitude_deg) + " deg, Altitude (AMSL) " +
+                             std::to_string(waypoint_altitude) + " meters";
+                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Info, status);
+
+                } else {
+                    _action->hold();
+
+                    status = std::string(missionManagerOut) + "Holding position...";
+                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
+                }
+
+                std::cout << status << std::endl;
+
+            } else if (safe_landing_on_no_safe_land == "LANDING_SITE_SEARCH") {
+                if (_global_origin_reference_set && _got_traj) {
+                    std::cout << "*" << std::endl
+                              << "***" << std::endl
+                              << "***** Starting Landing Site Search" << std::endl
+                              << "***" << std::endl
+                              << "*" << std::endl;
+
+                    status = "Starting Landing Site Search";
+                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
+
+                    // Set the landing speeds
+                    update_landing_speed_config();
+
+                    // Configure landing planner
+                    landing_planner::LandingPlannerConfig lp_config;
+                    lp_config.max_distance = landing_site_search_max_distance;
+                    lp_config.min_height = landing_site_search_min_height;
+                    lp_config.max_height = safe_landing_distance_to_ground;
+                    lp_config.min_distance_after_abort = landing_site_search_min_distance_after_abort;
+                    lp_config.waypoint_arrival_radius = landing_site_search_arrival_radius;
+                    lp_config.site_assess_time = landing_site_search_assess_time;
+                    lp_config.search_strategy = landing_site_search_strategy;
+                    lp_config.spiral_search_spacing = landing_site_search_spiral_spacing;
+                    lp_config.spiral_search_points = landing_site_search_spiral_points;
+
+                    // Start search
+                    _landing_planner.startSearch(_current_pos_x, _current_pos_y, _current_yaw, -_current_pos_z,
+                                                 lp_config);
+
+                    if (_landing_planner.isActive()) {
+                        // Set the first waypoint in the search pattern
+                        const mavsdk::geometry::CoordinateTransformation::LocalCoordinate new_wpt =
+                            _landing_planner.getCurrentWaypoint();
+                        go_to_new_local_waypoint(new_wpt);
+                    } else {
+                        // Planner did not start correctly.
+                        _action->hold();
+                        landing_site_search_has_ended("NSC");
+
+                        status =
+                            std::string(missionManagerOut) + "Landing planner could not start. Holding position...";
+                        _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
+                    }
+                } else if (!_global_origin_reference_set) {
+                    // Planner did not start correctly.
+                    _action->hold();
+                    landing_site_search_has_ended("No GO");
+
+                    status = std::string(missionManagerOut) + "Global position reference not set. Holding position...";
+                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Error, status);
+                } else if (!_got_traj) {
+                    _action->hold();
+                    landing_site_search_has_ended("No OA");
+
+                    status = std::string(missionManagerOut) +
+                             "Landing planner could not start. No OA active in PX4. Holding position...";
+                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Error, status);
+                }
+
+                std::cout << status << std::endl;
+            } else if (safe_landing_on_no_safe_land == "GO_TO_WAYPOINT_XYZ") {
+                _action->hold();
+
+                status = std::string(missionManagerOut) +
+                         "GO_TO_WAYPOINT_XYZ action currently not supported for Safe Landing. Holding position...";
                 _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
                 std::cout << status << std::endl;
 
-                _action_triggered = true;
-                _last_time = now;
-            } else if (should_trigger_safe_landing) {
-                std::cout << std::string(missionManagerOut) << "Cannot land! ----------------------- ("
-                          << safe_landing_state << ")" << std::endl;
-                if (safe_landing_on_no_safe_land == "HOLD") {
-                    _action->hold();
+            } else if (safe_landing_on_no_safe_land == "MOVE_LLA_WRT_CURRENT") {
+                _action->hold();
 
-                    status = std::string(missionManagerOut) + "Position hold triggered for Safe Landing";
-                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Info, status);
-                    std::cout << status << std::endl;
+                status = std::string(missionManagerOut) +
+                         "MOVE_LLA_WRT_CURRENT action currently not supported for Safe Landing. Holding position...";
+                _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
+                std::cout << status << std::endl;
 
-                } else if (safe_landing_on_no_safe_land == "RTL") {
+            } else if (safe_landing_on_no_safe_land == "GO_TO_WAYPOINT") {
+                std::string status{};
+
+                // If this action run previously, but the user didn't change the waypoint online after the
+                // action was triggered, the previous waypoint will match the current waypoint. If that's the
+                // case enfore an RTL so to avoid the vehicle getting stuck trying to land in a place it can't
+                // land
+                if ((std::abs(global_position_waypoint_lat - _current_latitude) <= 1.0E-5) &&
+                    (std::abs(global_position_waypoint_lon - _current_longitude) <= 1.0E-5) &&
+                    (std::abs(_previously_set_waypoint_altitude_amsl - _current_altitude_amsl) <= 1.0)) {
                     _action->return_to_launch();
 
-                    status = std::string(missionManagerOut) + "RTL triggered for Safe Landing";
-                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Info, status);
-                    std::cout << status << std::endl;
+                    status = std::string(missionManagerOut) +
+                             "Go-To Global Position Waypoint not triggered for Safe Landing, as the waypoint set "
+                             "is the same as the "
+                             "global position of the vehicle."
+                             "RTL triggered instead...";
+                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
 
-                } else if (safe_landing_on_no_safe_land == "MOVE_XYZ_WRT_CURRENT") {
+                } else {
                     // get the global origin from the FMU and set the reference
                     if (_global_origin_reference_set) {
-                        const auto waypoint =
-                            get_global_position_from_local_offset(local_position_offset_x, local_position_offset_y);
-                        const double waypoint_altitude = _current_altitude_amsl + local_position_offset_z;
+                        // then send the DO_REPOSITION
+                        _action->goto_location(global_position_waypoint_lat, global_position_waypoint_lon,
+                                               global_position_waypoint_alt_amsl, NAN);
 
-                        _action->goto_location(waypoint.latitude_deg, waypoint.longitude_deg, waypoint_altitude, NAN);
-
-                        set_new_waypoint(waypoint.latitude_deg, waypoint.longitude_deg, waypoint_altitude);
+                        set_new_waypoint(global_position_waypoint_lat, global_position_waypoint_lon,
+                                         global_position_waypoint_alt_amsl);
 
                         status = std::string(missionManagerOut) +
-                                 "Moving XYZ WRT to current vehicle position triggered for Safe Landing. Heading to "
-                                 "determined "
-                                 "Latitude " +
-                                 std::to_string(waypoint.latitude_deg) + " deg, Longitude " +
-                                 std::to_string(waypoint.longitude_deg) + " deg, Altitude (AMSL) " +
-                                 std::to_string(waypoint_altitude) + " meters";
+                                 "Go-To Global Position Waypoint triggered for Safe Landing. Heading to Latitude " +
+                                 std::to_string(global_position_waypoint_lat) + " deg, Longitude " +
+                                 std::to_string(global_position_waypoint_lon) + " deg, Altitude (AMSL) " +
+                                 std::to_string(global_position_waypoint_alt_amsl) + " meters";
                         _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Info, status);
 
                     } else {
@@ -587,154 +702,29 @@ void MissionManager::handle_safe_landing(std::chrono::time_point<std::chrono::sy
                         status = std::string(missionManagerOut) + "Holding position...";
                         _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
                     }
-
-                    std::cout << status << std::endl;
-
-                } else if (safe_landing_on_no_safe_land == "LANDING_SITE_SEARCH") {
-                    if (_global_origin_reference_set && _got_traj) {
-                        std::cout << "*" << std::endl
-                                  << "***" << std::endl
-                                  << "***** Starting Landing Site Search" << std::endl
-                                  << "***" << std::endl
-                                  << "*" << std::endl;
-
-                        status = "Starting Landing Site Search";
-                        _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-
-                        // Set the landing speeds
-                        update_landing_speed_config();
-
-                        // Configure landing planner
-                        landing_planner::LandingPlannerConfig lp_config;
-                        lp_config.max_distance = landing_site_search_max_distance;
-                        lp_config.min_height = landing_site_search_min_height;
-                        lp_config.max_height = safe_landing_distance_to_ground;
-                        lp_config.min_distance_after_abort = landing_site_search_min_distance_after_abort;
-                        lp_config.waypoint_arrival_radius = landing_site_search_arrival_radius;
-                        lp_config.site_assess_time = landing_site_search_assess_time;
-                        lp_config.search_strategy = landing_site_search_strategy;
-                        lp_config.spiral_search_spacing = landing_site_search_spiral_spacing;
-                        lp_config.spiral_search_points = landing_site_search_spiral_points;
-
-                        // Start search
-                        _landing_planner.startSearch(_current_pos_x, _current_pos_y, _current_yaw, -_current_pos_z,
-                                                     lp_config);
-
-                        if (_landing_planner.isActive()) {
-                            // Set the first waypoint in the search pattern
-                            const mavsdk::geometry::CoordinateTransformation::LocalCoordinate new_wpt =
-                                _landing_planner.getCurrentWaypoint();
-                            go_to_new_local_waypoint(new_wpt);
-                        } else {
-                            // Planner did not start correctly.
-                            _action->hold();
-                            landing_site_search_has_ended("NSC");
-
-                            status =
-                                std::string(missionManagerOut) + "Landing planner could not start. Holding position...";
-                            _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-                        }
-                    } else if (!_global_origin_reference_set) {
-                        // Planner did not start correctly.
-                        _action->hold();
-                        landing_site_search_has_ended("No GO");
-
-                        status =
-                            std::string(missionManagerOut) + "Global position reference not set. Holding position...";
-                        _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Error, status);
-                    } else if (!_got_traj) {
-                        _action->hold();
-                        landing_site_search_has_ended("No OA");
-
-                        status = std::string(missionManagerOut) +
-                                 "Landing planner could not start. No OA active in PX4. Holding position...";
-                        _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Error, status);
-                    }
-
-                    std::cout << status << std::endl;
-                } else if (safe_landing_on_no_safe_land == "GO_TO_WAYPOINT_XYZ") {
-                    _action->hold();
-
-                    status = std::string(missionManagerOut) +
-                             "GO_TO_WAYPOINT_XYZ action currently not supported for Safe Landing. Holding position...";
-                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-                    std::cout << status << std::endl;
-
-                } else if (safe_landing_on_no_safe_land == "MOVE_LLA_WRT_CURRENT") {
-                    _action->hold();
-
-                    status =
-                        std::string(missionManagerOut) +
-                        "MOVE_LLA_WRT_CURRENT action currently not supported for Safe Landing. Holding position...";
-                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-                    std::cout << status << std::endl;
-
-                } else if (safe_landing_on_no_safe_land == "GO_TO_WAYPOINT") {
-                    std::string status{};
-
-                    // If this action run previously, but the user didn't change the waypoint online after the
-                    // action was triggered, the previous waypoint will match the current waypoint. If that's the
-                    // case enfore an RTL so to avoid the vehicle getting stuck trying to land in a place it can't
-                    // land
-                    if ((std::abs(global_position_waypoint_lat - _current_latitude) <= 1.0E-5) &&
-                        (std::abs(global_position_waypoint_lon - _current_longitude) <= 1.0E-5) &&
-                        (std::abs(_previously_set_waypoint_altitude_amsl - _current_altitude_amsl) <= 1.0)) {
-                        _action->return_to_launch();
-
-                        status = std::string(missionManagerOut) +
-                                 "Go-To Global Position Waypoint not triggered for Safe Landing, as the waypoint set "
-                                 "is the same as the "
-                                 "global position of the vehicle."
-                                 "RTL triggered instead...";
-                        _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-
-                    } else {
-                        // get the global origin from the FMU and set the reference
-                        if (_global_origin_reference_set) {
-                            // then send the DO_REPOSITION
-                            _action->goto_location(global_position_waypoint_lat, global_position_waypoint_lon,
-                                                   global_position_waypoint_alt_amsl, NAN);
-
-                            set_new_waypoint(global_position_waypoint_lat, global_position_waypoint_lon,
-                                             global_position_waypoint_alt_amsl);
-
-                            status = std::string(missionManagerOut) +
-                                     "Go-To Global Position Waypoint triggered for Safe Landing. Heading to Latitude " +
-                                     std::to_string(global_position_waypoint_lat) + " deg, Longitude " +
-                                     std::to_string(global_position_waypoint_lon) + " deg, Altitude (AMSL) " +
-                                     std::to_string(global_position_waypoint_alt_amsl) + " meters";
-                            _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Info, status);
-
-                        } else {
-                            _action->hold();
-
-                            status = std::string(missionManagerOut) + "Holding position...";
-                            _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-                        }
-                    }
-
-                    std::cout << status << std::endl;
-
-                } else if (safe_landing_on_no_safe_land == "SCRIPT_CALL") {
-                    _action->hold();
-
-                    status = std::string(missionManagerOut) +
-                             "SCRIPT_CALL action currently not supported for Safe Landing. Holding position...";
-                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-                    std::cout << status << std::endl;
-
-                } else if (safe_landing_on_no_safe_land == "API_CALL") {
-                    _action->hold();
-
-                    status = std::string(missionManagerOut) +
-                             "API_CALL action currently not supported for Safe Landing. Holding position...";
-                    _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
-                    std::cout << status << std::endl;
                 }
 
-                _action_triggered = true;
-                _last_time = now;
+                std::cout << status << std::endl;
+
+            } else if (safe_landing_on_no_safe_land == "SCRIPT_CALL") {
+                _action->hold();
+
+                status = std::string(missionManagerOut) +
+                         "SCRIPT_CALL action currently not supported for Safe Landing. Holding position...";
+                _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
+                std::cout << status << std::endl;
+
+            } else if (safe_landing_on_no_safe_land == "API_CALL") {
+                _action->hold();
+
+                status = std::string(missionManagerOut) +
+                         "API_CALL action currently not supported for Safe Landing. Holding position...";
+                _server_utility->send_status_text(mavsdk::ServerUtility::StatusTextType::Warning, status);
+                std::cout << status << std::endl;
             }
+
+            _action_triggered = true;
+            _last_time = now;
         }
     }
 

--- a/src/modules/mission_manager/MissionManager.hpp
+++ b/src/modules/mission_manager/MissionManager.hpp
@@ -157,6 +157,7 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
                                     const float height_above_obstacle, const bool land_when_found_site);
     void landing_site_search_has_ended(const std::string& _debug = "");
 
+    void create_avoidance_mavlink_heartbeat_message();
     void send_avoidance_mavlink_heartbeat();
 
     void on_mavlink_trajectory_message(const mavlink_message_t& _message);
@@ -249,6 +250,9 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
     std::thread _decision_maker_th;
     std::thread _global_origin_reference_th;
 
+    mavlink_message_t _oa_heartbeat_message;
+
+    rclcpp::Time _time_last_heartbeat;
     rclcpp::Time _time_last_traj;
 
     std::atomic<bool> _got_traj;

--- a/src/modules/mission_manager/MissionManager.hpp
+++ b/src/modules/mission_manager/MissionManager.hpp
@@ -147,6 +147,8 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
         _height_above_obstacle_update_callback = callback;
     }
 
+    bool isHealthy() const { return _is_healthy; }
+
     void decision_maker_run();
 
    private:
@@ -255,6 +257,7 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
     rclcpp::Time _time_last_heartbeat;
     rclcpp::Time _time_last_traj;
 
+    std::atomic<bool> _is_healthy;
     std::atomic<bool> _got_traj;
 
     timing_tools::FrequencyMeter _frequency_traj;

--- a/src/modules/mission_manager/MissionManager.hpp
+++ b/src/modules/mission_manager/MissionManager.hpp
@@ -159,9 +159,6 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
                                     const float height_above_obstacle, const bool land_when_found_site);
     void landing_site_search_has_ended(const std::string& _debug = "");
 
-    void create_avoidance_mavlink_heartbeat_message();
-    void send_avoidance_mavlink_heartbeat();
-
     void on_mavlink_trajectory_message(const mavlink_message_t& _message);
     void flight_mode_callback(const mavsdk::Telemetry::FlightMode& flight_mode);
 
@@ -252,9 +249,6 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
     std::thread _decision_maker_th;
     std::thread _global_origin_reference_th;
 
-    mavlink_message_t _oa_heartbeat_message;
-
-    rclcpp::Time _time_last_heartbeat;
     rclcpp::Time _time_last_traj;
 
     std::atomic<bool> _is_healthy;

--- a/src/modules/mission_manager/MissionManager.hpp
+++ b/src/modules/mission_manager/MissionManager.hpp
@@ -204,7 +204,7 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
     std::shared_ptr<mavsdk::ServerUtility> _server_utility;
     std::shared_ptr<mavsdk::MavlinkPassthrough> _mavlink_passthrough;
 
-    std::atomic<bool> _action_triggered;
+    std::atomic<bool> _action_in_progress;
     std::atomic<mavsdk::Telemetry::FlightMode> _flight_mode{mavsdk::Telemetry::FlightMode::Unknown};
     std::atomic<mavsdk::Telemetry::LandedState> _landed_state{mavsdk::Telemetry::LandedState::Unknown};
     std::atomic<mavsdk::Telemetry::LandedState> _previous_landed_state{mavsdk::Telemetry::LandedState::Unknown};

--- a/src/modules/mission_manager/MissionManager.hpp
+++ b/src/modules/mission_manager/MissionManager.hpp
@@ -157,6 +157,8 @@ class MissionManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
                                     const float height_above_obstacle, const bool land_when_found_site);
     void landing_site_search_has_ended(const std::string& _debug = "");
 
+    void send_avoidance_mavlink_heartbeat();
+
     void on_mavlink_trajectory_message(const mavlink_message_t& _message);
     void flight_mode_callback(const mavsdk::Telemetry::FlightMode& flight_mode);
 

--- a/src/modules/sensor_manager/SensorManager.cpp
+++ b/src/modules/sensor_manager/SensorManager.cpp
@@ -53,6 +53,7 @@ SensorManager::SensorManager(std::shared_ptr<mavsdk::System> mavsdk_system)
       _tf_depth_filter(_tf_buffer, NED_FRAME, 10, this->create_sub_node("tf_filter")),
       _time_last_odometry{this->now()},
       _time_last_image{this->now()},
+      _is_healthy{true},
       _frequency_images("sensor images"),
       _frequency_camera_info("sensor camera_info"),
       _frequency_odometry("sensor odometry") {}
@@ -283,7 +284,7 @@ void SensorManager::health_check() {
 
     const bool is_odom_healthy = s_since_last_odom < std::chrono::duration<double>(2.5s).count();
     const bool is_image_healthy = s_since_last_image < std::chrono::duration<double>(2.5s).count();
-    const bool is_healthy = is_odom_healthy && is_image_healthy;
+    _is_healthy = is_odom_healthy && is_image_healthy;
 
     const rclcpp::Duration warning_interval(2, 0);
     static rclcpp::Time last_warning = now;
@@ -291,7 +292,7 @@ void SensorManager::health_check() {
 
     static bool health_reported_once = false;
 
-    if (!is_healthy && is_exceeded) {
+    if (!_is_healthy && is_exceeded) {
         last_warning = now;
 
         std::stringstream ss;

--- a/src/modules/sensor_manager/SensorManager.cpp
+++ b/src/modules/sensor_manager/SensorManager.cpp
@@ -42,6 +42,9 @@
 
 using namespace std::chrono_literals;
 
+static constexpr auto health_check_interval = 100ms;
+static constexpr auto time_sync_publish_interval = 100ms;
+
 SensorManager::SensorManager(std::shared_ptr<mavsdk::System> mavsdk_system)
     : Node("sensor_manager"),
       _mavsdk_system{std::move(mavsdk_system)},
@@ -150,8 +153,9 @@ auto SensorManager::run() -> void {
         _time_sync.run(tsync.ts1, tsync.tc1, this->now().nanoseconds() / 1000ULL);
     });
 
-    _timer_health_check_task = create_wall_timer(100ms, std::bind(&SensorManager::health_check, this));
-    _timer_time_sync_task = create_wall_timer(100ms, std::bind(&SensorManager::publish_time_sync, this));
+    _timer_health_check_task = create_wall_timer(health_check_interval, std::bind(&SensorManager::health_check, this));
+    _timer_time_sync_task =
+        create_wall_timer(time_sync_publish_interval, std::bind(&SensorManager::publish_time_sync, this));
 
     rclcpp::spin(shared_from_this());
 }

--- a/src/modules/sensor_manager/SensorManager.hpp
+++ b/src/modules/sensor_manager/SensorManager.hpp
@@ -107,6 +107,8 @@ class SensorManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modul
 
     void health_check();
 
+    void publish_time_sync();
+
     mutable std::mutex _sensor_manager_mutex;
 
     rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr _depth_img_camera_info_sub;
@@ -137,7 +139,8 @@ class SensorManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modul
 
     geometry_msgs::msg::TransformStamped _camera_static_tf;
 
-    rclcpp::TimerBase::SharedPtr _timer_status_task;
+    rclcpp::TimerBase::SharedPtr _timer_health_check_task;
+    rclcpp::TimerBase::SharedPtr _timer_time_sync_task;
 
     rclcpp::Time _time_last_odometry;
     rclcpp::Time _time_last_image;

--- a/src/modules/sensor_manager/SensorManager.hpp
+++ b/src/modules/sensor_manager/SensorManager.hpp
@@ -95,6 +95,8 @@ class SensorManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modul
 
     void set_camera_static_tf(const double x, const double y, const double yaw_deg);
 
+    bool isHealthy() const { return _is_healthy; }
+
    private:
     void handle_incoming_camera_info(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
     void handle_incoming_depth_image(const sensor_msgs::msg::Image::ConstSharedPtr& msg);
@@ -137,6 +139,8 @@ class SensorManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modul
 
     rclcpp::Time _time_last_odometry;
     rclcpp::Time _time_last_image;
+
+    bool _is_healthy;
 
     TimeSync _time_sync;
 

--- a/src/modules/sensor_manager/SensorManager.hpp
+++ b/src/modules/sensor_manager/SensorManager.hpp
@@ -95,9 +95,11 @@ class SensorManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modul
 
     void set_camera_static_tf(const double x, const double y, const double yaw_deg);
 
-    bool isHealthy() const { return _is_healthy; }
+    bool isHealthy() const { return _health_status == HealthStatus::HEALTHY; }
 
    private:
+    enum HealthStatus { HEALTHY = 0, UNHEALTHY_ODOMETRY = 1, UNHEALTHY_IMAGES = 2, UNHEALTHY_ODOMETRY_AND_IMAGES = 3 };
+
     void handle_incoming_camera_info(const sensor_msgs::msg::CameraInfo::ConstSharedPtr& msg);
     void handle_incoming_depth_image(const sensor_msgs::msg::Image::ConstSharedPtr& msg);
 
@@ -140,7 +142,7 @@ class SensorManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modul
     rclcpp::Time _time_last_odometry;
     rclcpp::Time _time_last_image;
 
-    bool _is_healthy;
+    HealthStatus _health_status;
 
     TimeSync _time_sync;
 


### PR DESCRIPTION
#### Problem

When the Autopilot Manager is running, it sent out a heartbeat for the Obstacle Avoidance (OA) system (component 196) even when OA had been disabled or Safe Landing (SL) was inactive.
This caused the OA indicator in the AMC top bar to show, even though the OA ought to be disabled and "out of sight".

#### Changes

This sets the heartbeat to only be sent when OA is enabled and SL is active.
This meant that some of the logic about when to check whether to start a landing site search could be simplified.

Furthermore, the heartbeat is now only sent when all important components are healthy, specifically:
- the Sensor Manager is receiving image and odometry data,
- the Landing Manager is receiving images and odometry from the Sensor Manager, and
- the Misison Manager is receiving a stream of OA interface wayppoint messages.

#### Testing
SITL

_OA indicator:_
- The OA indicator is only visible when OA is enabled (`COM_OBS_AVOID == 1`).
   - Green when SL is enabled and running.
   - Red when SL is disabled or not running.
- There seems to be an issue in AMC:
   - When OA is switched from disabled to enabled,the indicator does not appear (incorrect).
   - When OA is switched from enabled to disabled,the indicator disappears (correct).

_Enabling/disabling logic:_
- Landing site search only kicks in if OA and SL are enabled.
- Disabling OA while a landing site search is being executed results in a hold.
- Take-off is denied if OA is enabled but SL is either disabled or not running correctly.

---

**Jira Task:** [AVOID-292](https://auterion.atlassian.net/browse/AVOID-292) & [AVOID-293](https://auterion.atlassian.net/browse/AVOID-293)

**Does this PR need to be backported to the stable release?** No

**Does this PR need to update any documentation (readme, confluence, gitbook, etc.)?** No

[AVOID-292]: https://auterion.atlassian.net/browse/AVOID-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ