### PR TITLE
DIS-3274: Don't print stats when disabled

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autopilot-manager</name>
-  <version>1.2.4</version>
+  <version>1.2.5</version>
   <description>Autopilot Manager</description>
 
   <maintainer email="nuno@auterion.com">Nuno Marques</maintainer>

--- a/src/modules/landing_manager/LandingManager.cpp
+++ b/src/modules/landing_manager/LandingManager.cpp
@@ -45,7 +45,7 @@ using namespace std::placeholders;
 
 static constexpr auto mapper_interval = 100ms;
 static constexpr auto visualisation_interval = 1s;
-static constexpr auto print_stats_interval = 5s;
+static constexpr auto print_stats_interval = 30s;
 
 LandingManager::LandingManager(std::shared_ptr<mavsdk::System> mavsdk_system)
     : Node("landing_manager"),

--- a/src/modules/landing_manager/LandingManager.hpp
+++ b/src/modules/landing_manager/LandingManager.hpp
@@ -142,6 +142,8 @@ class LandingManager : public rclcpp::Node, public ObstacleAvoidanceModule, Modu
 
     void printStats();
 
+    bool isEnabledInConfig() const;
+
     std::shared_ptr<mavsdk::System> _mavsdk_system;
     std::shared_ptr<mavsdk::ServerUtility> _server_utility;
 


### PR DESCRIPTION
**Jira Task:** [DIS-3274](https://auterion.atlassian.net/browse/DIS-3274)

#### Does this PR need to be backported to the stable release?
No

#### Does this PR need to update any documentation (readme, confluence, gitbook, etc.)?
No

#### Describe your solution

Even when Safe Landing was disabled, if the Autopilot Manager was running, the scheduled printout of various timing and image processing statistics still ran.
This logging will now only run when Safe Landing has been configured to be "enabled" (in the relevant config files).

This change also reduces the frequency of the printout from once every 5s to every 30s when Safe Landing _is_ enabled.

#### Test data / coverage

- Skynode


[DIS-3274]: https://auterion.atlassian.net/browse/DIS-3274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ